### PR TITLE
Update Node.js base image to version 18-buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:lts-slim as frontend-build
+FROM node:18-buster-slim as frontend-build
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm install
 COPY frontend/ ./
 RUN npm run build
 
-FROM node:lts-slim
+FROM node:18-buster-slim
 WORKDIR /app
 
 COPY backend/package*.json ./


### PR DESCRIPTION
This pull request updates the Node.js base image used in the `Dockerfile` for both the frontend build and the main application runtime. The change ensures a consistent and specific Node.js version and Debian base for improved reliability and reproducibility.

Dockerfile improvements:

* Updated the base image from `node:lts-slim` to `node:18-buster-slim` for both the `frontend-build` stage and the final runtime stage, ensuring a specific Node.js version and Debian release are used.